### PR TITLE
Fix Article Search, use exponential backdown, update to version 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
   - "pypy3"
 
 install:

--- a/pynytimes/__init__.py
+++ b/pynytimes/__init__.py
@@ -2,4 +2,4 @@
 from .api import NYTAPI
 
 __all__ = ["NYTAPI"]
-__version__ = "0.2"
+__version__ = "0.3"

--- a/pynytimes/api.py
+++ b/pynytimes/api.py
@@ -195,7 +195,7 @@ class NYTAPI:
 
         self.session.mount("https://", HTTPAdapter(max_retries = retry_strategy))
 
-        self.session.headers.update({"User-Agent": "pynytimes/0.2"})
+        self.session.headers.update({"User-Agent": "pynytimes/0.3"})
 
         if self.key is None:
             raise Exception("No API key")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     include_package_data = True,
     url="https://github.com/michadenheijer/pynytimes",
     license="MIT",
-    install_requires = ["requests==2.22.0"],
+    install_requires = ["requests==2.23.0"],
     classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3 :: Only"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pynytimes",
-    version="0.2.1",
+    version="0.3",
     description="A Python wrapper for (most) New York Times APIs",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests.py
+++ b/tests.py
@@ -1,12 +1,7 @@
 from pynytimes import NYTAPI
 
 import datetime
-import random
-import time
 import os
-
-random_wait = random.randint(0, 60)
-time.sleep(random_wait)
 
 begin = datetime.datetime.now()
 
@@ -14,40 +9,45 @@ API_KEY = os.environ["NewYorkTimesAPIKey"]
 nyt = NYTAPI(API_KEY)
 
 nyt.top_stories(section="science")
+
 nyt.most_viewed(days=30)
-time.sleep(5)
+
 nyt.most_shared(
     days = 30,
     method = "email"
 )
+
 nyt.book_reviews(
     author = "Michelle Obama"
 )
-time.sleep(5)
+
 nyt.best_sellers_lists()
+
 nyt.best_sellers_list(
     date = datetime.datetime(2019, 1, 1),
     name = "hardcover-fiction"
 )
-time.sleep(5)
+
 nyt.movie_reviews(
     keyword = "FBI",
     options = {
         "order": "by-opening-date"
     }
 )
+
 nyt.article_metadata(
     url = "https://www.nytimes.com/2019/10/20/world/middleeast/erdogan-turkey-nuclear-weapons-trump.html"
 )
-time.sleep(5)
+
 nyt.tag_query(
     "Pentagon",
     max_results = 20
 )
+
 nyt.archive_metadata(
     date = datetime.datetime(2019, 1, 1)
 )
-time.sleep(5)
+
 nyt.article_search(
     query = "Trump",
     results = 20,


### PR DESCRIPTION
# Fix Article Search

There were some errors for the Article Search (#1), to resolve the issue all error status codes will be raised.

# Use exponential backoff

This should help solve problems when you get the HTTP Error 429 (Too Many Requests), it automatically slows down requests.

# Update to version 0.3

There are some changes, but there are no breaking changes. The only change that could potentially be breaking is the option ```"rate_limiting": False``` in article search. This options has been disabled, the library will now continuously make requests until it gets the status code 429, then it'll use the exponential backoff.

Also ```requests``` has been updated from version ```2.22.0``` to ```2.23.0```.