### PR TITLE
Add additional server error strategy

### DIFF
--- a/pynytimes/api.py
+++ b/pynytimes/api.py
@@ -188,13 +188,20 @@ class NYTAPI:
         self.key = key
         self.session = requests.Session()
 
-        retry_strategy = Retry(
+        backoff_strategy = Retry(
             total = 10,
             backoff_factor = 1,
-            status_forcelist = [429, 500, 502, 503, 504]
+            status_forcelist = [429, 509]
         )
 
-        self.session.mount("https://", HTTPAdapter(max_retries = retry_strategy))
+        server_error_strategy = Retry(
+            total = 2,
+            backoff_factor = 1,
+            status_forcelist = [500, 502, 503, 504]
+        )
+
+        self.session.mount("https://", HTTPAdapter(max_retries = backoff_strategy))
+        self.session.mount("https://", HTTPAdapter(max_retries = server_error_strategy))
 
         self.session.headers.update({"User-Agent": "pynytimes/" + __version__})
 


### PR DESCRIPTION
Since the NYTAPI currently returns a Gateway Error (504) for the Times Tags API, I needed to handle this errors much sooner. Now I've added an additional Error Retry Strategy for 5xx errors.